### PR TITLE
Destroy() should also destroy the pdf.js instance

### DIFF
--- a/jquery.touchPDF.js
+++ b/jquery.touchPDF.js
@@ -263,7 +263,7 @@
 		*/
 		this.destroy = function () {
 			$element.empty().removeClass("touchPDF");
-			
+			pdfDoc.destroy();
 		};
 
 		/**


### PR DESCRIPTION
Otherwise its webworkers stick around and hog memory
